### PR TITLE
Leading zeros are possible at "Deutsche Bank"

### DIFF
--- a/library/IBAN/Rule/DE/Rule002002.php
+++ b/library/IBAN/Rule/DE/Rule002002.php
@@ -21,8 +21,15 @@ class Rule002002 extends \IBAN\Rule\DE\Rule000000
             $bankAccountNumber = $instituteIdentificationReplacement[$instituteIdentification . "#" . $bankAccountNumber];
         }
 
+        // Accounts from "Deutsche Bank" have to be at least 7 digits in length.
+        // Leading zero's are possible
+        if (strlen($bankAccountNumber) < 7) {
+            $bankAccountNumber = str_pad($bankAccountNumber, 7, '0', STR_PAD_LEFT);
+        }
+
         if (substr($instituteIdentification, 3, 1) == '7') {
-            if (strlen( $bankAccountNumber) == 7) {
+            // For correct IBAN generation the sub account from "Deutsche Bank" has to be included
+            if (strlen($bankAccountNumber) == 7) {
                 $bankAccountNumber = str_pad($bankAccountNumber, 9, '0', STR_PAD_RIGHT);
             }
         }

--- a/tests/library/IBAN/Generation/IBANGeneratorTest.php
+++ b/tests/library/IBAN/Generation/IBANGeneratorTest.php
@@ -13,7 +13,7 @@ class IBANGeneratorTest extends \PHPUnit_Framework_TestCase
 		$ibanGenerator = new IBANGenerator(new RuleFactory('DE'));
 		$this->assertInstanceOf('IBAN\Generation\IBANGenerator', $ibanGenerator);
 	}
-	
+
     /**
      * @expectedException InvalidArgumentException
      */
@@ -31,9 +31,9 @@ class IBANGeneratorTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testGenerate_ValidIban()
-    {	
+    {
     	$generatorTestData = file('tests/data/generation.data');
-    	
+
         foreach ($generatorTestData as $testData) {
             $testDataArray = explode(';', trim($testData));
             $generatedIban = IBANGenerator::DE(trim($testDataArray[1]), trim($testDataArray[2]));
@@ -50,12 +50,12 @@ class IBANGeneratorTest extends \PHPUnit_Framework_TestCase
     {
     	$this->assertIban('NL02ABNA0123456789', IBANGenerator::NL('ABNA', '123 4567 89'));
     }
-    
+
     public function testGenerateIbanMT()
     {
     	$this->assertIban('MT84MALT011000012345MTLCAST001S', IBANGenerator::MT('MALT' . '01100', '0012345MTLCAST001S'));
     }
-    
+
     /**
      * @expectedException Exception
      */
@@ -259,6 +259,13 @@ class IBANGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGenerateIbanForRuleDE002001()
     {
         $this->assertIban('DE04500700100350002200', IBANGenerator::DE('50070010', '3500022'));
+    }
+
+    public function testGenerateIbanForRuleDE002002()
+    {
+        $this->assertIban('DE77230707000030038500', IBANGenerator::DE('23070700', '0300385'));
+        $this->assertIban('DE77230707000030038500', IBANGenerator::DE('23070700', '300385'));
+        $this->assertIban('DE24230707000130038500', IBANGenerator::DE('23070700', '1300385'));
     }
 
     public function testGenerateIbanForRuleDE002101()


### PR DESCRIPTION
"Deutsche Bank" has account numbers with leading zeros. All accounts
have to be at least 7 digits in length. If the account numbers without the leading
zeros are supplied to the IBAN generation they will result in wrong IBAN numbers.
Added some comments to explain this rule.
