### PR TITLE
Fix difference between local_bcmod and native bcmod

### DIFF
--- a/library/IBAN/Core/IBAN.php
+++ b/library/IBAN/Core/IBAN.php
@@ -159,7 +159,7 @@ class IBAN
                 $mod = $a % $y;
             } while (strlen($x));
 
-            return (int)$mod;
+            return (string)$mod;
         } else {
             return bcmod($x, $y);
         }


### PR DESCRIPTION
Since `isChecksumValid` does a strict comparison, `local_bcmod` should return a string just like the native `bcmod` function does